### PR TITLE
Add a rectangle shape for nodes

### DIFF
--- a/daft.py
+++ b/daft.py
@@ -396,7 +396,7 @@ class Node(object):
             val2 = np.abs(complex(dxx2, dyy2))
             
 
-            if val1 < 0.1*val2:
+            if val1 < val2:
                 return x1 + dxx1, y1 + dyy1
             else:
                 return x1 + dxx2, y1 + dyy2

--- a/daft.py
+++ b/daft.py
@@ -386,13 +386,13 @@ class Node(object):
             theta = np.angle(complex(dx, dy))
             #print(theta)
             #left or right intersection
-            dxx1 = self.scale*a/2.*np.sign(dx)
-            dyy1 = self.scale*a/2.*np.abs(dy/dx)*np.sign(dy)
+            dxx1 = self.scale*a/2.*(np.sign(dx) or 1.)
+            dyy1 = self.scale*a/2.*np.abs(dy/dx)*(np.sign(dy) or 1.)
             val1 = np.abs(complex(dxx1, dyy1))
 
             #up or bottom intersection
-            dxx2 =  self.scale*0.5*np.abs(dx/dy)*np.sign(dx ) 
-            dyy2 =  self.scale*0.5*np.sign(dy ) 
+            dxx2 =  self.scale*0.5*np.abs(dx/dy)*(np.sign(dx ) or 1.)
+            dyy2 =  self.scale*0.5*(np.sign(dy ) or 1.)
             val2 = np.abs(complex(dxx2, dyy2))
             
 
@@ -486,13 +486,21 @@ class Edge(object):
             p["head_width"] = p.get("head_width", 0.1)
 
             # Build an arrow.
-            ar = FancyArrow(*self._get_coords(ctx), width=0,
-                            length_includes_head=True,
-                            **p)
+            args = self._get_coords(ctx)
 
-            # Add the arrow to the axes.
-            ax.add_artist(ar)
-            return ar
+            #zero lengh arrow produce error
+            if not(args[2] == 0. and args[3] == 0.): 
+                ar = FancyArrow(*self._get_coords(ctx), width=0,
+                    length_includes_head=True, **p)
+
+                # Add the arrow to the axes.
+                ax.add_artist(ar)
+                return ar
+
+            else:
+                print(args[2], args[3] )
+
+
         else:
             p["color"] = p.get("color", "k")
 


### PR DESCRIPTION
All is in the title, now you can make the node represented by a rectangle or an ellipse, ellipse is still the default configuration. I have coded this as close as your api as I can.

The reason why I've choosen you project, is my need of many export format provided by matplotlib, and the absolute need of support for latex formula.
