### PR TITLE
set default mpl backend to non-interactive ++

### DIFF
--- a/daft.py
+++ b/daft.py
@@ -6,7 +6,6 @@ __all__ = ["PGM", "Node", "Edge", "Plate"]
 __version__ = "0.0.4"
 
 import matplotlib
-matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from matplotlib.patches import Ellipse
 from matplotlib.patches import FancyArrow
@@ -51,17 +50,22 @@ class PGM(object):
     :param label_params: (optional)
         Default node label parameters.
 
+    :param backend: (optional)
+        The default matplotlib backend.
     """
     def __init__(self, shape, origin=[0., 0.],
                  grid_unit=2., node_unit=1.,
                  observed_style="shaded",
                  line_width=1., node_ec="k",
                  directed=True, aspect=1.0,
-                 label_params={}):
+                 label_params={}, backend=None):
         self._nodes = {}
         self._edges = []
         self._plates = []
-
+        if backend:
+            matplotlib.use(backend,warn=False, force=True )
+            import matplotlib.pyplot as plt
+            print ("matplotlib backend:", matplotlib.get_backend())
         self._ctx = _rendering_context(shape=shape, origin=origin,
                                        grid_unit=grid_unit,
                                        node_unit=node_unit,

--- a/daft.py
+++ b/daft.py
@@ -5,10 +5,13 @@ from __future__ import division, print_function
 __all__ = ["PGM", "Node", "Edge", "Plate"]
 __version__ = "0.0.4"
 
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from matplotlib.patches import Ellipse
 from matplotlib.patches import FancyArrow
 from matplotlib.patches import Rectangle as Rectangle
+
 
 import numpy as np
 
@@ -218,8 +221,8 @@ class Node(object):
         if shape in ["ellipse", "rectangle"]:
             self.shape = shape
         else:
-            print("Warning: wrong shape value, set to ellispe instead")
-            self.shape = "ellispe"
+            print("Warning: wrong shape value, set to ellipse instead")
+            self.shape = "ellipse"
 
     def render(self, ctx):
         """


### PR DESCRIPTION
matplotlib default backend is "interactive" which requires x11 (tested on RHEL7)
Setting backend to "Agg" should resolve that. 
(https://matplotlib.org/faq/howto_faq.html#generate-images-without-having-a-window-appear)

Fix a typo for setting illegal shapes to ellipse.
